### PR TITLE
Our pytest_collection_modifyitems hook should be run last

### DIFF
--- a/interactive/plugin.py
+++ b/interactive/plugin.py
@@ -30,6 +30,7 @@ def pytest_configure(config):
         pytest.exit(1)
 
 
+@pytest.mark.trylast
 def pytest_collection_modifyitems(session, config, items):
     """called after collection has been performed, may filter or re-order
     the items in-place.


### PR DESCRIPTION
Otherwise we have a potential conflict with other plugins using this hook, such as pytest-ordering.

What's happening:
1. pytest-interactive brings up the ipython shell.
2. I run a test marked with `pytest.mark.second`.
3. pytest-ordering now kicks in and reorders this test.
4. Test now fails to start because it can no longer be found.
